### PR TITLE
Update azure-pipelines-1.yml

### DIFF
--- a/azure-pipelines-1.yml
+++ b/azure-pipelines-1.yml
@@ -17,3 +17,23 @@ steps:
     echo Add other tasks to build, test, and deploy your project.
     echo See https://aka.ms/yaml
   displayName: 'Run a multi-line script'
+            - name: Cache
+  uses: actions/cache@v4.2.3
+  with:
+    # A list of files, directories, and wildcard patterns to cache and restore
+    path: 
+    # An explicit key for restoring and saving the cache
+    key: 
+    # An ordered multiline string listing the prefix-matched keys, that are used for restoring stale cache if no cache hit occurred for key. Note `cache-hit` returns false in this case.
+    restore-keys: # optional
+    # The chunk size used to split up large files during upload, in bytes
+    upload-chunk-size: # optional
+    # An optional boolean when enabled, allows windows runners to save or restore caches that can be restored or saved respectively on other platforms
+    enableCrossOsArchive: # optional, default is false
+    # Fail the workflow if cache entry is not found
+    fail-on-cache-miss: # optional, default is false
+    # Check if a cache entry exists for the given input(s) (key, restore-keys) without downloading the cache
+    lookup-only: # optional, default is false
+    # Run the post step to save the cache even if another step before fails
+    save-always: # optional, default is false
+          


### PR DESCRIPTION
- name: Cache
uses: actions/cache@v4.2.3
with:
  # A list of files, directories, and wildcard patterns to cache and restore
  path: 
  # An explicit key for restoring and saving the cache
  key: 
  # An ordered multiline string listing the prefix-matched keys, that are used for restoring stale cache if no cache hit occurred for key. Note `cache-hit` returns false in this case.
  restore-keys: # optional
  # The chunk size used to split up large files during upload, in bytes
  upload-chunk-size: # optional
  # An optional boolean when enabled, allows windows runners to save or restore caches that can be restored or saved respectively on other platforms
  enableCrossOsArchive: # optional, default is false
  # Fail the workflow if cache entry is not found
  fail-on-cache-miss: # optional, default is false
  # Check if a cache entry exists for the given input(s) (key, restore-keys) without downloading the cache
  lookup-only: # optional, default is false
  # Run the post step to save the cache even if another step before fails
  save-always: # optional, default is false

## Summary by Sourcery

CI:
- Include a caching task with configurable parameters (path, key, restore-keys, upload-chunk-size, enableCrossOsArchive, fail-on-cache-miss, lookup-only, save-always) in azure-pipelines-1.yml